### PR TITLE
fix(rmnch): stop garbage device timestamps from corrupting CreatedDate

### DIFF
--- a/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
+++ b/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
@@ -219,8 +219,26 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 											.getByRegID(benRegID).get(0);
 									if (temp != null) {
 										obj.setBeneficiaryDetails_RmnchId(temp.getBeneficiaryDetails_RmnchId());
+										if (isPlausibleDeviceTimestamp(temp.getCreatedDate())) {
+											// Already has a good CreatedDate from the first sync — a later
+											// re-sync must never overwrite it.
+											obj.setCreatedDate(temp.getCreatedDate());
+										} else if (isPlausibleDeviceTimestamp(obj.getCreatedDate())) {
+											// Stored value was garbage but this re-sync brought a plausible
+											// one from the device — self-heal using it (obj already has it).
+										} else {
+											obj.setCreatedDate(new Timestamp(System.currentTimeMillis()));
+										}
 									}
+								} else if (!isPlausibleDeviceTimestamp(obj.getCreatedDate())) {
+									// Device clock is broken (unset -> 1970 epoch, or set ahead -> future
+									// date). We can't recover the true capture time, so fall back to the
+									// sync time as the least-wrong value instead of storing garbage.
+									obj.setCreatedDate(new Timestamp(System.currentTimeMillis()));
 								}
+								// else: trust the device-supplied CreatedDate as-is — offline captures
+								// legitimately sync well after the actual event, so a later server time
+								// would be less accurate than the device's own timestamp.
 
 
 
@@ -653,6 +671,22 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 		return (obj.has(key) && !obj.get(key).isJsonNull())
 				? obj.get(key).getAsInt()
 				: defaultVal;
+	}
+
+	/**
+	 * A device-supplied CreatedDate is trustworthy only if it is non-null,
+	 * not the classic unset-clock epoch default, and not after the current
+	 * server time (an offline capture can only have happened before the sync
+	 * request that reports it, so a future date means the device's clock is
+	 * wrong, not that the record is legitimately from the future).
+	 */
+	private boolean isPlausibleDeviceTimestamp(Timestamp createdDate) {
+		if (createdDate == null) {
+			return false;
+		}
+		long epochDayZero = 24L * 60 * 60 * 1000; // guard band around 1970-01-01 for epoch defaults
+		long now = System.currentTimeMillis();
+		return createdDate.getTime() > epochDayZero && createdDate.getTime() <= now;
 	}
 
 	private boolean hasAnthropometryData(RMNCHBeneficiaryDetailsRmnch obj) {


### PR DESCRIPTION
i_beneficiarydetails_rmnch.CreatedDate was trusting whatever the syncing device sent, with no validation. Confirmed on UAT: 48/463 rows future-dated (up to 2026-08-29, ~3 weeks ahead), 6/463 stuck at the 1970 epoch default — both classic broken-device-clock symptoms (never set, or set ahead).

Add isPlausibleDeviceTimestamp() (rejects null, epoch-default, and future-dated values) and apply it in syncDataToAmrit()'s RMNCH beneficiary details block:
- Existing record already has a plausible CreatedDate -> keep it; a later re-sync must never overwrite a good value with a possibly-bad one.
- Existing record's value is bad but this sync's incoming value is plausible -> self-heal using the incoming value.
- Neither is plausible (broken clock both times) -> fall back to server sync time as the least-wrong value instead of storing garbage.
- New record with a plausible device value -> trust it as-is, since offline captures legitimately sync well after the actual event.

Build verified: mvn -o clean compile, BUILD SUCCESS.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
