### PR TITLE
fix(stoptb): fix RMNCH VanID placeholder-zero and id/VanSerialNo coll…

### DIFF
--- a/src/main/java/com/iemr/common/identity/repo/rmnch/RMNCHBeneficiaryDetailsRmnchRepo.java
+++ b/src/main/java/com/iemr/common/identity/repo/rmnch/RMNCHBeneficiaryDetailsRmnchRepo.java
@@ -24,10 +24,12 @@ package com.iemr.common.identity.repo.rmnch;
 import java.math.BigInteger;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.iemr.common.identity.data.rmnch.RMNCHBeneficiaryDetailsRmnch;
 
@@ -39,4 +41,13 @@ public interface RMNCHBeneficiaryDetailsRmnchRepo extends CrudRepository<RMNCHBe
 
 	@Query(" SELECT t FROM RMNCHBeneficiaryDetailsRmnch t WHERE t.BenRegId =:benRegID ")
 	public List<RMNCHBeneficiaryDetailsRmnch> getByRegID(@Param("benRegID") BigInteger benRegId);
+
+	// The Java field bound to the VanSerialNo column is literally named `id` with no
+	// @SerializedName - any incoming JSON that happens to carry its own "id" key (e.g. a
+	// client-side list-item id) collides with it during Gson deserialization and silently
+	// overwrites the intended VanSerialNo value. Force it back to the row's own PK after save.
+	@Transactional
+	@Modifying
+	@Query("UPDATE RMNCHBeneficiaryDetailsRmnch t SET t.id = :id WHERE t.beneficiaryDetails_RmnchId = :id")
+	void updateVanSerialNo(@Param("id") BigInteger id);
 }

--- a/src/main/java/com/iemr/common/identity/repo/rmnch/RMNCHHouseHoldDetailsRepo.java
+++ b/src/main/java/com/iemr/common/identity/repo/rmnch/RMNCHHouseHoldDetailsRepo.java
@@ -21,10 +21,12 @@
 */
 package com.iemr.common.identity.repo.rmnch;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.iemr.common.identity.data.rmnch.RMNCHHouseHoldDetails;
 
@@ -37,4 +39,13 @@ public interface RMNCHHouseHoldDetailsRepo extends CrudRepository<RMNCHHouseHold
 
 	@Query("SELECT t FROM RMNCHHouseHoldDetails t WHERE t.houseoldId = :houseoldId")
 	List<RMNCHHouseHoldDetails> getByHouseHoldID(@Param("houseoldId") long houseoldId);
+
+	// The Java field bound to the VanSerialNo column is literally named `id` with no
+	// @SerializedName - any incoming JSON that happens to carry its own "id" key collides
+	// with it during Gson deserialization and silently overwrites the intended VanSerialNo
+	// value. Force it back to the row's own PK after save.
+	@Transactional
+	@Modifying
+	@Query("UPDATE RMNCHHouseHoldDetails t SET t.id = :id WHERE t.houseHoldDetailsId = :id")
+	void updateVanSerialNo(@Param("id") Long id);
 }

--- a/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
+++ b/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
@@ -255,7 +255,9 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 									}
 									obj.setRelatedBeneficiaryIdsDB(sb.toString());
 								}
-								if (obj.getVanID() == null && vanID != null) {
+								// Mobile sends VanID=0 as a placeholder (not null) for a fresh record —
+								// `== null` alone never catches it, leaving the placeholder in place.
+								if ((obj.getVanID() == null || obj.getVanID() == 0) && vanID != null) {
 									obj.setVanID(vanID);
 									obj.setParkingPlaceID(parkingPlaceID);
 								}
@@ -297,6 +299,10 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 							List<RMNCHBeneficiaryDetailsRmnch> benDetailsOriginalList = new ArrayList<>(benDetailsExtraList);
 							benDetailsExtraList = (ArrayList<RMNCHBeneficiaryDetailsRmnch>) rMNCHBeneficiaryDetailsRmnchRepo
 									.saveAll(benDetailsExtraList);
+							// The `id`/VanSerialNo field is Gson-collision-prone (see repo javadoc) —
+							// force it back to each row's own PK after save.
+							benDetailsExtraList.forEach((n) -> rMNCHBeneficiaryDetailsRmnchRepo
+									.updateVanSerialNo(n.getBeneficiaryDetails_RmnchId()));
 
 							benDetailsExtraList.forEach((n) -> beneficiaryDetailsIds.add(n.getId()));
 							// update beneficiary data in i_beneficiarydetails table
@@ -413,6 +419,10 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 							}
 							houseHoldList = (ArrayList<RMNCHHouseHoldDetails>) rMNCHHouseHoldDetailsRepo
 									.saveAll(houseHoldList);
+							// The `id`/VanSerialNo field is Gson-collision-prone (see repo javadoc) —
+							// force it back to each row's own PK after save.
+							houseHoldList.forEach((n) -> rMNCHHouseHoldDetailsRepo
+									.updateVanSerialNo(n.getHouseHoldDetailsId()));
 							// success response
 							houseHoldList.forEach((n) -> houseHoldDetailsIds.add(n.getId()));
 						}


### PR DESCRIPTION
…ision

- RMNCHBeneficiaryDetailsRmnch: mobile sends VanID=0 as a placeholder (not null) for a fresh record - the existing '== null' check never caught it, leaving the real vanID from Redis unapplied. Now checks for both null and 0.
- Both RMNCHBeneficiaryDetailsRmnch and RMNCHHouseHoldDetails map their VanSerialNo column to a Java field literally named 'id' with no @SerializedName - any incoming JSON payload that happens to carry its own 'id' key collides with it during Gson deserialization, silently overwriting the intended VanSerialNo with whatever unrelated value the client sent (observed live: every row stuck at VanSerialNo=1). Added updateVanSerialNo() to both repos and call it after each saveAll(), same pattern already used for i_beneficiaryimage/i_beneficiaryaddress in IdentityService.createIdentity().
- Left RMNCHCBACdetails/RMNCHBornBirthDetails alone despite sharing the same id-collision pattern - not part of the Stop TB flow, zero rows in practice, out of scope for this fix.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
