### PR TITLE
fix(stoptb): read vanID from stoptb.van.id property instead of Redis

### DIFF
--- a/src/main/environment/1097_ci.properties
+++ b/src/main/environment/1097_ci.properties
@@ -38,4 +38,7 @@ elasticsearch.enabled=@env.ELASTICSEARCH_ENABLED@
 # stays false — but must still be set explicitly, since IdentityService.java (shared with
 # the common_* build) now requires this property with no inline default.
 stoptb.enforce.vanid=false
+# Same reasoning — not a van deployment, but RmnchDataSyncServiceImpl (shared with the
+# common_* build) now requires this property explicitly, no inline default.
+stoptb.van.id=0
 

--- a/src/main/environment/1097_docker.properties
+++ b/src/main/environment/1097_docker.properties
@@ -38,4 +38,7 @@ elasticsearch.enabled=${ELASTICSEARCH_ENABLED}
 # stays false — but must still be set explicitly, since IdentityService.java (shared with
 # the common_* build) now requires this property with no inline default.
 stoptb.enforce.vanid=false
+# Same reasoning — not a van deployment, but RmnchDataSyncServiceImpl (shared with the
+# common_* build) now requires this property explicitly, no inline default.
+stoptb.van.id=0
 

--- a/src/main/environment/1097_example.properties
+++ b/src/main/environment/1097_example.properties
@@ -35,4 +35,7 @@ elasticsearch.enabled=true
 # stays false — but must still be set explicitly, since IdentityService.java (shared with
 # the common_* build) now requires this property with no inline default.
 stoptb.enforce.vanid=false
+# Same reasoning — not a van deployment, but RmnchDataSyncServiceImpl (shared with the
+# common_* build) now requires this property explicitly, no inline default.
+stoptb.van.id=0
 

--- a/src/main/environment/common_ci.properties
+++ b/src/main/environment/common_ci.properties
@@ -24,6 +24,8 @@ spring.redis.host=@env.REDIS_HOST@
 
 # Stop TB: when true, RMNCH data sync fails with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=@env.STOPTB_ENFORCE_VANID@
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=@env.STOPTB_VAN_ID@
 
 cors.allowed-origins=@env.CORS_ALLOWED_ORIGINS@
 

--- a/src/main/environment/common_docker.properties
+++ b/src/main/environment/common_docker.properties
@@ -24,6 +24,8 @@ spring.redis.host=${REDIS_HOST}
 
 # Stop TB: when true, RMNCH data sync fails with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=${STOPTB_ENFORCE_VANID}
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=${STOPTB_VAN_ID}
 
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
 

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -21,6 +21,8 @@ spring.redis.host=localhost
 # Stop TB: when true, RMNCH data sync fails with an error if camp (vanID) is not
 # configured instead of silently skipping vanID stamping
 stoptb.enforce.vanid=false
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=0
 
 cors.allowed-origins=http://localhost:*
 

--- a/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
+++ b/src/main/java/com/iemr/common/identity/service/rmnch/RmnchDataSyncServiceImpl.java
@@ -76,7 +76,6 @@ import com.iemr.common.identity.repo.rmnch.RMNCHHouseHoldDetailsRepo;
 import com.iemr.common.identity.repo.rmnch.RMNCHMBenMappingRepo;
 import com.iemr.common.identity.domain.MBeneficiarydetail;
 import com.iemr.common.identity.repo.BenDetailRepo;
-import com.iemr.common.identity.utils.redis.RedisStorage;
 import com.iemr.common.identity.repo.rmnch.RMNCHMBenRegIdMapRepo;
 import com.iemr.common.identity.utils.config.ConfigProperties;
 import com.iemr.common.identity.utils.exception.IEMRException;
@@ -119,11 +118,19 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 	private RMNCHMBenRegIdMapRepo rMNCHMBenRegIdMapRepo;
 	@Autowired
 	private BenDetailRepo benDetailRepo;
-	@Autowired
-	private RedisStorage redisStorage;
 
 	@Value("${fhir-url}")
 	private String fhirUrl;
+
+	// This deployment's van/camp ID. Previously looked up from Redis ("camp:vanID"),
+	// written at MMU login and deleted (globally, unscoped) on ANY user's logout — a Redis
+	// outage or an unrelated user's logout would silently break sync on this camp. Each
+	// camp/van already runs its own dedicated backend instance, so which van this is never
+	// actually changes at runtime; reading it from properties removes the Redis dependency
+	// entirely. No inline default — every properties file must set this explicitly.
+	// Scope: vanID only, parkingPlaceID is not part of this change.
+	@Value("${stoptb.van.id}")
+	private int configuredVanID;
 
 	// When true, sync fails loudly if camp is not configured instead of silently
 	// skipping vanID stamping. No inline default — every properties file must set this
@@ -142,23 +149,16 @@ public class RmnchDataSyncServiceImpl implements RmnchDataSyncService {
 		ArrayList<Long> cBACDetailsIds = new ArrayList<>();
 		ArrayList<Long> houseHoldDetailsIds = new ArrayList<>();
 
-		// Read camp vanID/parkingPlaceID from Redis (set by MMU-API on van login)
-		Integer campVanID = null;
-		Integer campParkingPlaceID = null;
-		try {
-			String vanVal = redisStorage.getRaw("camp:vanID");
-			String ppVal = redisStorage.getRaw("camp:parkingPlaceID");
-			if (vanVal != null && !vanVal.isBlank()) campVanID = Integer.parseInt(vanVal);
-			if (ppVal != null && !ppVal.isBlank()) campParkingPlaceID = Integer.parseInt(ppVal);
-		} catch (Exception ignored) {
-			// no camp configured — vanID stamping skipped
-		}
+		// Configured van ID for this deployment (see configuredVanID field javadoc above).
+		// parkingPlaceID is out of scope for this change — kept null, same as before whenever
+		// Redis had no value for it.
+		Integer campVanID = configuredVanID > 0 ? configuredVanID : null;
 		if (campVanID == null && enforceVanID) {
 			throw new Exception(
-					"Camp not configured: vanID missing. Please select van/service point in MMU before syncing data.");
+					"Camp not configured: stoptb.van.id is 0. Set stoptb.van.id in this deployment's properties file.");
 		}
 		final Integer vanID = campVanID;
-		final Integer parkingPlaceID = campParkingPlaceID;
+		final Integer parkingPlaceID = null;
 
 		try {
 			if (requestOBJ != null && !requestOBJ.isEmpty()) {


### PR DESCRIPTION
Redis (camp:vanID) was written once at MMU login and deleted globally, unscoped, on ANY user's logout — a Redis outage or an unrelated user's logout would silently break RMNCH sync on this camp. Each camp/van already runs its own dedicated backend instance, so which van this is never actually changes at runtime.

syncDataToAmrit() now reads vanID from the new stoptb.van.id property (no inline default, every properties file must set it explicitly, same convention as stoptb.enforce.vanid) instead of an inline Redis lookup via RedisStorage. Removed the now-unused RedisStorage dependency from this class.

Added stoptb.van.id=0 to the 1097 (Helpline) profile's properties files too, since RmnchDataSyncServiceImpl is shared with that build and the property now has no inline default.

Scope: vanID only, parkingPlaceID is not part of this change.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
